### PR TITLE
fix inconsistent license information

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ from __future__ import (unicode_literals, division, absolute_import,
 # PyUnresolvedReferences
 from calibre.customize import InterfaceActionBase
 
-__license__ = 'GPL v3'
+__license__ = 'GPL v2+'
 __copyright__ = '2015 Stanislaw Szczesniak'
 __docformat__ = 'restructuredtext en'
 

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ from __future__ import (unicode_literals, division, absolute_import,
 from PyQt5.Qt import QWidget, QHBoxLayout, QLabel, QLineEdit
 from calibre.utils.config import JSONConfig
 
-__license__ = 'GPL v3'
+__license__ = 'GPL v2+'
 __copyright__ = '2015 Stanislaw Szczesniak'
 __docformat__ = 'restructuredtext en'
 


### PR DESCRIPTION
The copyright headers of `main.py` and `ui.py` state that they are
distributed under the conditions of the GPL version 2 or later, but the
`__license__` variables in `__init__.py` and `config.py` were set to "GPL v3".
I've changed them to "GPL v2+" to be consistent with the copyright
headers.
